### PR TITLE
fix_style_proposal_main_mobile

### DIFF
--- a/app/assets/stylesheets/custom/custom_proposal.scss
+++ b/app/assets/stylesheets/custom/custom_proposal.scss
@@ -317,6 +317,11 @@
             }
           }
         }
+        @include breakpoint(small down){
+          .proposals-page .proposal-bottom .margin-bottom .button-custom{
+            display: none;
+          }
+        }
       }
     }
 

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <div class="row no-images">
         <div class="small-12 <%= css_for_proposal_info_row(proposal) %>">
-      <% end %>
+    <% end %>
         <div class="proposal-content">
           <% cache [locale_and_user_status(proposal), "index", proposal, proposal.author] do %>
             <h3><%= link_to proposal.title, namespaced_proposal_path(proposal) %></h3>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -110,9 +110,9 @@
 
     <div class="small-12 medium-3 column">
       <aside class="margin-bottom">
-        <%= link_to t("proposals.index.start_proposal"),
+        <!-- <%= link_to t("proposals.index.start_proposal"),
                     new_proposal_path,
-                    class: "button expanded button-custom" %>
+                    class: "button expanded button-custom" %> -->
 
         <div class="sidebar-divider"></div>
       <h2 class="sidebar-title"><%= t("proposals.index.selected_proposals") %></h2>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -108,11 +108,11 @@
       </div>
     </div>
 
-    <div class="small-12 medium-3 column">
+    <div class="small-12 medium-3 column proposal-bottom">
       <aside class="margin-bottom">
-        <!-- <%= link_to t("proposals.index.start_proposal"),
+        <%= link_to t("proposals.index.start_proposal"),
                     new_proposal_path,
-                    class: "button expanded button-custom" %> -->
+                    class: "button expanded button-custom" %> 
 
         <div class="sidebar-divider"></div>
       <h2 class="sidebar-title"><%= t("proposals.index.selected_proposals") %></h2>

--- a/config/locales/th/images.yml
+++ b/config/locales/th/images.yml
@@ -15,4 +15,4 @@ th:
     errors:
       messages:
         in_between: must be in between %{min} and %{max}
-        wrong_content_type: content type %{content_type} does not match any of accepted content types %{accepted_content_types}
+        wrong_content_type: ประเภทของรูปภาพ %{content_type} ไม่ถูกรองรับ ยกเว้นประเภท %{accepted_content_types}


### PR DESCRIPTION
@First commit
แปลภาษา
content type image/png does not match any of accepted content types jpg เป็น ประเภทรูปภาพ image/png ไม่ถูกร้องรับ ยกเว้นประเภท jpg
ลบ div สร้างนโยบายประชาชนออก สำหรับ mobile ที่อยู่ตรง footer
แก้กล้องที่ styles ตอนที่ถูก selected สำหรับไม่มีรูปภาพ

@Second commit
commit แรก ตอนหน้า mobile div สร้างนโยบายประชาชน ตอนที่เป็นหน้าปกติจะหายไปด้วย 
commit ที่สองเลยแก้เฉพาะตอนที่เป็น mobile ให้ display:none ไป (สำหรับหน้าจอปกติ จะแสดงเหมือนเดิม)